### PR TITLE
add input.json and output.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 __pycache__/
 *.py[cod]
 
-# logs
+# logs and runtime config files
 data/logs
+data/input.json
+data/output.json
 data/history.json
 
 # macos cache files


### PR DESCRIPTION
Add input.json and output.json to .gitignore to reduce false positive merge conflicts in future PRs.

# logs and runtime config files
data/logs
data/input.json
data/output.json
data/history.json